### PR TITLE
iterate over locale to get lengths

### DIFF
--- a/src/components/Scheduler.vue
+++ b/src/components/Scheduler.vue
@@ -15,24 +15,10 @@
             {{ i18n('WEEK_TITLE') }}
           </div>
         </th>
-        <th
-          class="scheduler-half-toggle"
-          :colspan="halfDaySpan"
-          @click="handleClickAM()"
-        >
-          {{ i18n('AM') }}
-        </th>
-        <th
-          class="scheduler-half-toggle"
-          :colspan="halfDaySpan"
-          @click="handleClickPM()"
-        >
-          {{ i18n('PM') }}
-        </th>
       </tr>
       <tr>
         <td
-          v-for="n in 24"
+          v-for="n in i18n('HOURS', []).length"
           :key="n"
           class="scheduler-hour"
           :colspan="accuracy"
@@ -44,7 +30,7 @@
     </thead>
     <tbody>
       <tr
-        v-for="day in 7"
+        v-for="day in i18n('WEEK_DAYS').length"
         :key="day"
       >
         <td
@@ -134,7 +120,8 @@ export default {
       return this.accuracy * 12
     },
     cellColAmout () {
-      return this.accuracy * 24
+      // should access i18n here
+      return this.accuracy * 12
     }
   },
 


### PR DESCRIPTION
Hey there,

Here's a messy PR to give you an idea of an alternative. It's not intended to be mergeable, but it gives you an idea of a feature

For me, I don't want to have 24 hour schedules, or use all 7 days a week. This PR iterates over the length of the locale block to create the lengths of the week/day

Result:
![image](https://user-images.githubusercontent.com/1572410/95012224-32ca0380-0637-11eb-9fb5-d2ec779eb0a5.png)
